### PR TITLE
load(): pass instance to callback function

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ RunControl.prototype.load = function(callback) {
   if(typeof callback !== 'function') {
     throw new TypeError('Load callback must be a function');
   }
-  var files = this.path.slice(0), name = this.name;
+  var files = this.path.slice(0), name = this.name, self = this;
   //console.dir(files);
   var rc = this.rc, type = this.type, lenient = this.lenient, errors = null;
   files.forEach(function(dir, index, arr) {
@@ -120,7 +120,7 @@ RunControl.prototype.load = function(callback) {
     for(var i = 0;i < results.length;i++) {
       if(results[i]) merge(results[i], rc);
     }
-    callback(errors, rc);
+    callback(errors, rc, self);
   });
 }
 


### PR DESCRIPTION
if you do not retain the value returned by `rc()`, it's effectively impossible to get at the `path` if wrapping this function in the Q library:

``` js
// before this change:
Q.nfcall(require('cli-rc'))
  .then(function(config) {
    // now you have your data, but since the wrapper returns a Promise instead of a RunControl
    // instance, we must use a callback if we want it.
  });

// after:
Q.nfcall(require('cli-rc'))
  .spread(function(config, rc) {
    // now we have access to the instance, and thusly the path property.
  });
```
